### PR TITLE
feat(ci): Verify base image with cosign before building

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,12 +53,17 @@ jobs:
           - image_name: lazurite
             major_version: 38
     steps:
-      - name: Maximize build space
-        uses: ublue-os/remove-unwanted-software@v6
-
       # Checkout push-to-registry action GitHub repository
       - name: Checkout Push to Registry action
         uses: actions/checkout@v4
+
+      - name: Verify base image
+        uses: EyeCantCU/cosign-action/verify@v0.2.1
+        with:
+          containers: ${{ matrix.image_name }}-asus:${{ matrix.major_version }}
+
+      - name: Maximize build space
+        uses: ublue-os/remove-unwanted-software@v6
 
       - name: Matrix Variables
         run: |


### PR DESCRIPTION
Validate the integrity of base image being built from via cosign before continuing to build. Ensures we only build from signed images