### PR TITLE
chore(ci): lazurite 39 builds supercede lxqt 38

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,10 +29,10 @@ jobs:
           - sericea
           - base
           - lxqt
+          - lazurite
           - mate
           - onyx
           - vauxite
-          - lazurite
         major_version: [38, 39]
         driver_version: [470, 545]
         include:
@@ -52,6 +52,9 @@ jobs:
             major_version: 38
           - image_name: lazurite
             major_version: 38
+          # lazurite supercedes lxqt in Fedora 39
+          - image_name: lxqt
+            major_version: 39
     steps:
       # Checkout push-to-registry action GitHub repository
       - name: Checkout Push to Registry action


### PR DESCRIPTION
just some cleanup related to upstream main/nvidia changes for lazurite