### PR TITLE
chore(ci): fix possible empty version meta on image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,8 +140,14 @@ jobs:
 
       - name: Get current version
         id: labels
+        shell: bash
         run: |
+          set -eo pipefail
           ver=$(skopeo inspect docker://ghcr.io/ublue-os/${{ matrix.image_name }}-main:${{ matrix.major_version }} | jq -r '.Labels["org.opencontainers.image.version"]')
+          if [ -z "$ver" ] || [ "null" = "$ver" ]; then
+            echo "inspected image version must not be empty or null"
+            exit 1
+          fi
           echo "VERSION=$ver" >> $GITHUB_OUTPUT
 
       # Build metadata


### PR DESCRIPTION
This ensures that when inspecting upstream image, if an error occurs, or the resulting value is empty or 'null', we fail our build instead of propagating a bogus version downstream.

Relates: ublue-os/main#487